### PR TITLE
for rails 3.1: get rid of deprecation messages because of old #class_inheritable_reader

### DIFF
--- a/lib/app/models/read_mark.rb
+++ b/lib/app/models/read_mark.rb
@@ -12,6 +12,5 @@ class ReadMark < ActiveRecord::Base
   send scope_method, :user,          lambda { |user|           { :conditions => { :user_id => user.id }}}
   send scope_method, :older_than,    lambda { |timestamp|      { :conditions => [ 'timestamp < ?', timestamp] }}
   
-  class_inheritable_reader :reader_class
-  class_inheritable_reader :readable_classes
+  send((Rails::VERSION::MAJOR == 3 ? :class_attribute : :class_inheritable_reader), :reader_class, :readable_classes)
 end

--- a/lib/unread/acts_as_readable.rb
+++ b/lib/unread/acts_as_readable.rb
@@ -18,11 +18,11 @@ module Unread
     
     def acts_as_readable(options={})
       options.reverse_merge!({ :on => :updated_at })
-      class_inheritable_reader :readable_options
+      send((Rails::VERSION::MAJOR == 3 ? :class_attribute : :class_inheritable_reader), :readable_options)
+      
       write_inheritable_attribute :readable_options, options
       
       self.has_many :read_marks, :as => :readable, :dependent => :delete_all
-      
       classes = ReadMark.readable_classes || []
       classes << self
       ReadMark.write_inheritable_attribute :readable_classes, classes


### PR DESCRIPTION
Hello! 

What about wrapping your plugin to a gem? 
