### PR TITLE
Added attr_accessible to all ReadMark attributes

### DIFF
--- a/lib/app/models/read_mark.rb
+++ b/lib/app/models/read_mark.rb
@@ -1,5 +1,6 @@
 class ReadMark < ActiveRecord::Base
   belongs_to :readable, :polymorphic => true
+  attr_accessible :readable_id, :user_id, :readable_type, :timestamp
   
   validates_presence_of :user_id, :readable_type
   


### PR DESCRIPTION
This fixes the mass assignment issue that arises when `config.active_record.whitelist_attributes = true` (the default for new apps since 3.2.3)
