### PR TITLE
Allow setting last_read_at time

### DIFF
--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -3,10 +3,11 @@ module Unread
     module ClassMethods
       def mark_as_read!(target, options)
         user = options[:for]
+        time = options[:last_read_at]
         assert_reader(user)
 
         if target == :all
-          reset_read_marks_for_user(user)
+          reset_read_marks_for_user(user, time)
         elsif target.is_a?(Array)
           mark_array_as_read(target, user)
         else
@@ -77,12 +78,12 @@ module Unread
         end
       end
 
-      def reset_read_marks_for_user(user)
+      def reset_read_marks_for_user(user, time = Time.now)
         assert_reader(user)
 
         ReadMark.transaction do
           ReadMark.delete_all :readable_type => self.base_class.name, :user_id => user.id
-          ReadMark.create!    :readable_type => self.base_class.name, :user_id => user.id, :timestamp => Time.now
+          ReadMark.create!    :readable_type => self.base_class.name, :user_id => user.id, :timestamp => time
         end
       end
 

--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -3,7 +3,7 @@ module Unread
     module ClassMethods
       def mark_as_read!(target, options)
         user = options[:for]
-        time = options[:last_read_at]
+        time = options[:last_read_at] || Time.now
         assert_reader(user)
 
         if target == :all

--- a/test/unread_test.rb
+++ b/test/unread_test.rb
@@ -131,6 +131,15 @@ class UnreadTest < ActiveSupport::TestCase
     assert_equal 0, ReadMark.single.count
     assert_equal 2, ReadMark.global.count
   end
+  
+  def test_mark_all_as_read_with_last_read_at
+    Email.mark_as_read! :all, :for => @reader, :last_read_at => 1.minute.ago.change(:usec => 0)
+
+    assert_equal 1.minute.ago.change(:usec => 0), @reader.read_mark_global(Email).timestamp.utc
+    assert_equal [@email2], Email.unread_by(@reader)
+    assert_equal 0, ReadMark.single.count
+    assert_equal 2, ReadMark.global.count
+  end
 
   def test_cleanup_read_marks
     assert_equal 0, @reader.read_marks.single.count


### PR DESCRIPTION
Describes the last point that notifications were checked. 

Default should be now. 