### PR TITLE
Improve caching for read_mark_global

### DIFF
--- a/lib/unread/reader.rb
+++ b/lib/unread/reader.rb
@@ -3,7 +3,9 @@ module Unread
     module InstanceMethods
       def read_mark_global(klass)
         instance_var_name = "@read_mark_global_#{klass.name.gsub('::','_')}"
-        instance_variable_get(instance_var_name) || begin # memoize
+        if instance_variables.include?(instance_var_name.to_sym)
+          instance_variable_get(instance_var_name)
+        else # memoize
           obj = self.read_marks.where(:readable_type => klass.base_class.name).global.first
           instance_variable_set(instance_var_name, obj)
         end


### PR DESCRIPTION
With old code it never fetches cached value from instance variable if it's nil. Fixed it
