### PR TITLE
Add support for eager_loading read_marks instead of joining

### DIFF
--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -114,7 +114,7 @@ module Unread
         # was most likely eager_loaded as part of
         # with_read_marks_eager_loaded_for which also adds the timestamp clause
         # necessary for this logic to be accurate.
-        elsif self.read_marks.loaded? && self.table_name != 'read_marks'
+        elsif self.read_marks.loaded? && self.class.table_name != 'read_marks'
           self.read_marks.length == 0
         else
           !!self.class.unread_by(user).exists?(self) # Rails4 does not return true/false, but nil/count instead.

--- a/lib/unread/scopes.rb
+++ b/lib/unread/scopes.rb
@@ -29,7 +29,7 @@ module Unread
       def with_read_marks_eager_loaded_for(user)
         eager_load(:read_marks)
           .where("read_marks.user_id = #{user.id} OR read_marks.user_id IS NULL")
-          .where("`read_marks`.`timestamp` >= `#{self.table_name}`.`created_at` OR read_marks.user_id IS NULL")
+          .where("read_marks.timestamp >= #{table_name}.#{readable_options[:on]} OR read_marks.user_id IS NULL")
       end
     end
   end

--- a/test/unread_test.rb
+++ b/test/unread_test.rb
@@ -49,6 +49,23 @@ class UnreadTest < ActiveSupport::TestCase
     assert_equal true, emails[1].unread?(@reader)
   end
 
+  def test_with_read_marks_eager_loaded_for
+    @email1.mark_as_read! :for => @reader
+
+    emails = Email.with_read_marks_eager_loaded_for(@reader).to_a
+
+    # Make sure this isn't using custom fields like with_read_marks_for, so it
+    # will work with other eager_loads.
+    assert !emails[0].respond_to?(:read_mark_id)
+
+    assert emails[0].read_marks.loaded?
+    assert emails[0].read_marks.count == 1
+    assert emails[1].read_marks.count == 0
+
+    assert_equal false, emails[0].unread?(@reader)
+    assert_equal true, emails[1].unread?(@reader)
+  end
+
   def test_scope_param_check
     [ 42, nil, 'foo', :foo, {} ].each do |not_a_reader|
       assert_raise(ArgumentError) { Email.unread_by(not_a_reader)}


### PR DESCRIPTION
I had a need to load a bunch of read marks all at once in a query that used eager_load. with_read_marks doesn't work here because the other eager_load's override the fields so the read_marks.id is never selected.

This meets my needs but could probably use a little polish as I'm very new to active record / rails.

Tests passing:
18 tests, 58 assertions, 0 failures, 0 errors, 0 skips
