### PR TITLE
Eager loading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ Message.unread_by(current_user)
 Message.cleanup_read_marks!
 ```
 
+### Using in conjunction with eager loading
+To preload read / unread status in a "query" that uses eager loading,
+_with_read_marks_for_ will not work. Instead, use _with_read_marks_eager_loaded_for_.
+
+```ruby
+class Message < ActiveRecord::Base
+  acts_as_readable :on => :created_at
+  has_many :users
+end
+
+## Get all messages with users eager loaded and including the read status for a given user
+messages = Message.eager_load(:users).with_read_marks_eager_loaded_for(current_user)
+```
+
 
 ## How does it work?
 

--- a/lib/unread/base.rb
+++ b/lib/unread/base.rb
@@ -29,6 +29,18 @@ module Unread
 
       has_many :read_marks, :as => :readable, :dependent => :delete_all
 
+      # Store for use in eager loaded conditions
+      readable_table_name = table_name
+      readable_class = base_class
+      # Used for eager loading
+      has_many :read_marks_eager,
+        -> {
+          where("#{table_name}.timestamp >= #{readable_table_name}.#{options[:on]}").
+            where "#{table_name}.readable_type = '#{readable_class.name}'"
+        },
+        :foreign_key => 'readable_id',
+        :class_name => "ReadMark"
+
       ReadMark.readable_classes ||= []
       ReadMark.readable_classes << self unless ReadMark.readable_classes.include?(self)
 

--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -109,6 +109,13 @@ module Unread
           else
             true
           end
+        # If read_marks has been eager_loaded, use that value, as long as the
+        # base table for this query is not read_marks. This means read_marks
+        # was most likely eager_loaded as part of
+        # with_read_marks_loaded_for which also adds the timestamp clause
+        # necessary for this logic to be accurate.
+        elsif self.read_marks_eager.loaded? && self.class.table_name != 'read_marks'
+          self.read_marks_eager.length == 0
         else
           !!self.class.unread_by(user).exists?(self) # Rails4 does not return true/false, but nil/count instead.
         end

--- a/lib/unread/scopes.rb
+++ b/lib/unread/scopes.rb
@@ -24,6 +24,12 @@ module Unread
       def with_read_marks_for(user)
         join_read_marks(user).select("#{table_name}.*, read_marks.id AS read_mark_id")
       end
+
+      # To be used when other eager_loading is done
+      def with_read_marks_eager_loaded_for(user)
+        eager_load(:read_marks_eager)
+          .where("read_marks.user_id = #{user.id} OR read_marks.user_id IS NULL")
+      end
     end
   end
 end

--- a/test/unread_test.rb
+++ b/test/unread_test.rb
@@ -49,6 +49,23 @@ class UnreadTest < ActiveSupport::TestCase
     assert_equal true, emails[1].unread?(@reader)
   end
 
+  def test_with_read_marks_loaded_for
+    @email1.mark_as_read! :for => @reader
+
+    emails = Email.with_read_marks_eager_loaded_for(@reader).to_a
+
+    # Make sure this isn't using custom fields like with_read_marks_for, so it
+    # will work with other eager_loads.
+    assert !emails[0].respond_to?(:read_mark_id)
+
+    assert emails[0].read_marks_eager.loaded?
+    assert emails[0].read_marks_eager.length == 1
+    assert emails[1].read_marks_eager.length == 0
+
+    assert_equal false, emails[0].unread?(@reader)
+    assert_equal true, emails[1].unread?(@reader)
+  end
+
   def test_scope_param_check
     [ 42, nil, 'foo', :foo, {} ].each do |not_a_reader|
       assert_raise(ArgumentError) { Email.unread_by(not_a_reader)}


### PR DESCRIPTION
This adds support for an eager_loaded scope as an alternative to the existing join-based scope. This is useful if you want to preload read marks in a query that already uses eager loading.

All tests passing:
18 runs, 58 assertions, 0 failures, 0 errors, 0 skips