### PR TITLE
Use newer migration syntax

### DIFF
--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -1,5 +1,5 @@
 class UnreadMigration < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :read_marks, :force => true do |t|
       t.integer  :readable_id
       t.integer  :user_id,       :null => false
@@ -8,9 +8,5 @@ class UnreadMigration < ActiveRecord::Migration
     end
 
     add_index :read_marks, [:user_id, :readable_type, :readable_id]
-  end
-
-  def self.down
-    drop_table :read_marks
   end
 end


### PR DESCRIPTION
The self.up/self.down syntax doesn't work on Rails 4 anyway, and now we can use the nicer change syntax :)
