### PR TITLE
Fix unread_by scope to work with associations

### DIFF
--- a/lib/unread/scopes.rb
+++ b/lib/unread/scopes.rb
@@ -14,6 +14,7 @@ module Unread
         result = join_read_marks(user).
                  where('read_marks.id IS NULL')
 
+        logger.warn "SELF: #{self.inspect}"
         if global_time_stamp = user.read_mark_global(self.base_class).try(:timestamp)
           result = result.where("#{table_name}.#{readable_options[:on]} > '#{global_time_stamp.to_s(:db)}'")
         end


### PR DESCRIPTION
In rails 4.1 Post.unread_by(user) works, but @site.posts.unread_by(user) does not,
as self refers to the association rather than the class, so read_mark_global is not found.

Using self.base_class fixes it up =)
