### PR TITLE
Use rails standard way to declare polymorphic associations

### DIFF
--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -2,7 +2,7 @@ class UnreadMigration < ActiveRecord::Migration
   def self.up
     create_table :read_marks, :force => true do |t|
       t.references :readable, polymorphic: { null: false }
-      t.integer  :user_id,       :null => false
+      t.references :user,     :null => false
       t.datetime :timestamp
     end
 

--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -1,9 +1,8 @@
 class UnreadMigration < ActiveRecord::Migration
   def self.up
     create_table :read_marks, :force => true do |t|
-      t.integer  :readable_id
+      t.references :readable, polymorphic: { null: false }
       t.integer  :user_id,       :null => false
-      t.string   :readable_type, :null => false
       t.datetime :timestamp
     end
 

--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -1,8 +1,8 @@
 class UnreadMigration < ActiveRecord::Migration
   def self.up
-    create_table :read_marks, :force => true do |t|
+    create_table :read_marks, force: true do |t|
       t.references :readable, polymorphic: { null: false }
-      t.references :user,     :null => false
+      t.references :user,     null: false
       t.datetime :timestamp
     end
 


### PR DESCRIPTION
The default template migration file is not compatible with this gem https://github.com/SchemaPlus/schema_plus

Because the gem enforce a foreign key for anything ends with <code>_id</code>.

So can we use the rails standard way <code>t.references</code> to declare the polymorphic associations ? I think it also provides better compatibility to other gems, and it looks shorter and nice.