### PR TITLE
Mark ProtectedAttributes line as nocov

### DIFF
--- a/lib/unread/read_mark.rb
+++ b/lib/unread/read_mark.rb
@@ -1,8 +1,10 @@
 class ReadMark < ActiveRecord::Base
   belongs_to :readable, :polymorphic => true
+  # :nocov:
   if defined?(ProtectedAttributes)
     attr_accessible :readable_id, :user_id, :readable_type, :timestamp
   end
+  # :nocov:
 
   validates_presence_of :user_id, :readable_type
 


### PR DESCRIPTION
This change will bring coveralls up to 100% test coverage.

I figured this line is not easy to test, so just thought it would be nice to ignore it.