### PR TITLE
Reader scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,36 @@ Message.unread_by(current_user)
 Message.read_by(current_user)
 # => [ message1, message2 ]
 
+## Get users that have not read a given message
+user1 = User.create!
+user2 = User.create!
+
+User.have_not_read(message1)
+# => [ user1, user2 ]
+
+message1.mark_as_read! :for => user1
+User.have_not_read(message1)
+# => [ user2 ]
+
+## Get users that have read a given message
+User.have_read(message1)
+# => [ ]
+
+message1.mark_as_read! :for => user1
+User.have_read(message1)
+# => [ user1 ]
+
+Message.mark_as_read! :all, :for => user1
+User.have_not_read(message1)
+# => [ user2 ]
+User.have_not_read(message2)
+# => [ user2 ]
+
+User.have_read(message1)
+# => [ user1 ]
+User.have_read(message2)
+# => [ user1 ]
+
 # Optional: Cleaning up unneeded markers.
 # Do this in a cron job once a day.
 Message.cleanup_read_marks!

--- a/README.md
+++ b/README.md
@@ -110,20 +110,20 @@ User.have_not_read(message1)
 
 ## Get users that have read a given message
 User.have_read(message1)
-# => [ ]
-
-message1.mark_as_read! :for => user1
-User.have_read(message1)
 # => [ user1 ]
+
+message1.mark_as_read! :for => user2
+User.have_read(message1)
+# => [ user1, user2 ]
 
 Message.mark_as_read! :all, :for => user1
 User.have_not_read(message1)
-# => [ user2 ]
+# => [ ]
 User.have_not_read(message2)
 # => [ user2 ]
 
 User.have_read(message1)
-# => [ user1 ]
+# => [ user1, user2 ]
 User.have_read(message2)
 # => [ user1 ]
 

--- a/lib/unread.rb
+++ b/lib/unread.rb
@@ -2,7 +2,8 @@ require 'unread/base'
 require 'unread/read_mark'
 require 'unread/readable'
 require 'unread/reader'
-require 'unread/scopes'
+require 'unread/readable_scopes'
+require 'unread/reader_scopes'
 require 'unread/version'
 
 ActiveRecord::Base.send :include, Unread

--- a/lib/unread/base.rb
+++ b/lib/unread/base.rb
@@ -22,6 +22,8 @@ module Unread
       ReadMark.reader_options = options
 
       include Reader::InstanceMethods
+      extend Reader::ClassMethods
+      extend Reader::Scopes
     end
 
     def acts_as_readable(options={})

--- a/lib/unread/readable_scopes.rb
+++ b/lib/unread/readable_scopes.rb
@@ -4,7 +4,7 @@ module Unread
       def join_read_marks(user)
         assert_reader(user)
 
-        joins "LEFT JOIN #{ReadMark.table_name} as read_marks ON read_marks.readable_type  = '#{base_class.name}'
+        joins "LEFT JOIN #{ReadMark.table_name} as read_marks ON read_marks.readable_type = '#{base_class.name}'
                                    AND read_marks.readable_id    = #{table_name}.#{primary_key}
                                    AND read_marks.user_id        = #{user.id}
                                    AND read_marks.timestamp     >= #{table_name}.#{readable_options[:on]}"

--- a/lib/unread/reader.rb
+++ b/lib/unread/reader.rb
@@ -1,5 +1,20 @@
 module Unread
   module Reader
+    module ClassMethods
+      def assert_readable(readable)
+        assert_readable_class
+
+        unless ReadMark.readable_classes.include?(readable.class)
+          raise ArgumentError, "Class #{readable.class.name} is not registered by acts_as_readable."
+        end
+        raise ArgumentError, "The given #{readable.class.name} has no id." unless readable.id
+      end
+
+      def assert_readable_class
+        raise RuntimeError, 'There is no class using acts_as_readable.' unless ReadMark.readable_classes.try(:any?)
+      end
+    end
+
     module InstanceMethods
       def read_mark_global(klass)
         @read_mark_global ||= {}
@@ -8,6 +23,15 @@ module Unread
 
       def forget_memoized_read_mark_global
         @read_mark_global = nil
+      end
+
+      def have_read?(readable)
+        if self.respond_to?(:read_mark_id)
+          # For use with scope "with_read_marks_for"
+          !self.read_mark_id.nil?
+        else
+          !self.class.have_not_read(readable).exists?(self.id)
+        end
       end
     end
   end

--- a/lib/unread/reader_scopes.rb
+++ b/lib/unread/reader_scopes.rb
@@ -1,0 +1,29 @@
+module Unread
+  module Reader
+    module Scopes
+      def join_read_marks(readable)
+        assert_readable(readable)
+
+        joins "LEFT JOIN #{ReadMark.table_name} as read_marks ON read_marks.readable_type = '#{readable.class.base_class.name}'
+               AND (read_marks.readable_id   = #{readable.try(readable.class.primary_key)} OR read_marks.readable_id IS NULL)
+               AND read_marks.user_id        = #{table_name}.#{primary_key}
+               AND read_marks.timestamp     >= '#{readable.try(readable.class.readable_options[:on]).to_s(:db)}'"
+      end
+
+      def have_not_read(readable)
+        join_read_marks(readable).where("read_marks.id IS NULL")
+      end
+
+      def have_read(readable)
+        join_read_marks(readable).where('read_marks.id IS NOT NULL')
+      end
+
+      def with_read_marks_for(readable)
+        join_read_marks(readable).select("#{table_name}.*,
+                                          read_marks.id AS read_mark_id,
+                                          '#{readable.class.base_class.name}' AS read_mark_readable_type,
+                                          #{readable.try(readable.class.primary_key)} AS read_mark_readable_id")
+      end
+    end
+  end
+end

--- a/lib/unread/reader_scopes.rb
+++ b/lib/unread/reader_scopes.rb
@@ -5,9 +5,9 @@ module Unread
         assert_readable(readable)
 
         joins "LEFT JOIN #{ReadMark.table_name} as read_marks ON read_marks.readable_type = '#{readable.class.base_class.name}'
-               AND (read_marks.readable_id   = #{readable.try(readable.class.primary_key)} OR read_marks.readable_id IS NULL)
+               AND (read_marks.readable_id   = #{readable.send(readable.class.primary_key)} OR read_marks.readable_id IS NULL)
                AND read_marks.user_id        = #{table_name}.#{primary_key}
-               AND read_marks.timestamp     >= '#{readable.try(readable.class.readable_options[:on]).to_s(:db)}'"
+               AND read_marks.timestamp     >= '#{readable.send(readable.class.readable_options[:on]).to_s(:db)}'"
       end
 
       def have_not_read(readable)
@@ -19,10 +19,7 @@ module Unread
       end
 
       def with_read_marks_for(readable)
-        join_read_marks(readable).select("#{table_name}.*,
-                                          read_marks.id AS read_mark_id,
-                                          '#{readable.class.base_class.name}' AS read_mark_readable_type,
-                                          #{readable.try(readable.class.primary_key)} AS read_mark_readable_id")
+        join_read_marks(readable).select("#{table_name}.*, read_marks.id AS read_mark_id")
       end
     end
   end

--- a/lib/unread/scopes.rb
+++ b/lib/unread/scopes.rb
@@ -26,7 +26,7 @@ module Unread
         result = join_read_marks(user)
 
         if global_time_stamp = user.read_mark_global(self).try(:timestamp)
-          result = result.where("read_marks.id IS NOT NULL OR #{table_name}.#{readable_options[:on]} <= ?", global_time_stamp).uniq
+          result = result.where("read_marks.id IS NOT NULL OR #{table_name}.#{readable_options[:on]} <= ?", global_time_stamp)
         else
           result = result.where('read_marks.id IS NOT NULL')
         end

--- a/lib/unread/scopes.rb
+++ b/lib/unread/scopes.rb
@@ -22,21 +22,11 @@ module Unread
         result
       end
 
-      def join_unread_marks(user)
-        assert_reader(user)
-
-        joins "LEFT JOIN #{ReadMark.table_name} as read_marks ON read_marks.readable_type  = '#{base_class.name}'
-                                   AND read_marks.readable_id    = #{table_name}.#{primary_key}
-                                   AND read_marks.user_id        = #{user.id}
-                                   AND read_marks.timestamp     <= #{table_name}.#{readable_options[:on]}"
-      end
-
       def read_by(user)
-        result = join_unread_marks(user)
+        result = join_read_marks(user)
 
         if global_time_stamp = user.read_mark_global(self).try(:timestamp)
-          result = result.where("read_marks.id IS NOT NULL
-                                 OR #{table_name}.#{readable_options[:on]} <= ?", global_time_stamp)
+          result = result.where("read_marks.id IS NOT NULL OR #{table_name}.#{readable_options[:on]} <= ?", global_time_stamp).uniq
         else
           result = result.where('read_marks.id IS NOT NULL')
         end

--- a/lib/unread/scopes.rb
+++ b/lib/unread/scopes.rb
@@ -22,11 +22,21 @@ module Unread
         result
       end
 
+      def join_unread_marks(user)
+        assert_reader(user)
+
+        joins "LEFT JOIN #{ReadMark.table_name} as read_marks ON read_marks.readable_type  = '#{base_class.name}'
+                                   AND read_marks.readable_id    = #{table_name}.#{primary_key}
+                                   AND read_marks.user_id        = #{user.id}
+                                   AND read_marks.timestamp     <= #{table_name}.#{readable_options[:on]}"
+      end
+
       def read_by(user)
-        result = join_read_marks(user)
+        result = join_unread_marks(user)
 
         if global_time_stamp = user.read_mark_global(self).try(:timestamp)
-          result = result.where("read_marks.id IS NOT NULL OR #{table_name}.#{readable_options[:on]} <= ?", global_time_stamp)
+          result = result.where("read_marks.id IS NOT NULL
+                                 OR #{table_name}.#{readable_options[:on]} <= ?", global_time_stamp)
         else
           result = result.where('read_marks.id IS NOT NULL')
         end

--- a/spec/read_mark_spec.rb
+++ b/spec/read_mark_spec.rb
@@ -8,4 +8,8 @@ describe ReadMark do
   it "should have reader_scope" do
     expect(ReadMark.reader_scope).to eq Reader.not_foo.not_bar
   end
+
+  it "should have readable_classes" do
+    expect(ReadMark.readable_classes).to eq [Email]
+  end
 end

--- a/spec/readable_spec.rb
+++ b/spec/readable_spec.rb
@@ -21,6 +21,8 @@ describe Unread::Readable do
 
       expect(Email.unread_by(@reader)).to eq [@email2]
       expect(Email.unread_by(@reader).count).to eq 1
+
+      expect(Email.unread_by(@other_reader)).to eq [@email1, @email2]
     end
 
     it "should not allow invalid parameter" do

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+
+describe Unread::Reader do
+  before :each do
+    @reader = Reader.create! :name => 'David'
+    @other_reader = Reader.create :name => 'Matz'
+    wait
+    @email1 = Email.create!
+    wait
+    @email2 = Email.create!
+  end
+
+  describe :have_not_read do
+    it "should return all readers that have not read a given object" do
+      expect(Reader.have_not_read(@email1)).to eq [@reader, @other_reader]
+      expect(Reader.have_not_read(@email2)).to eq [@reader, @other_reader]
+    end
+
+    it "should return *only* the readers that have not read a given object" do
+      @email1.mark_as_read! :for => @reader
+
+      expect(Reader.have_not_read(@email1)).to eq [@other_reader]
+      expect(Reader.have_not_read(@email1).count).to eq 1
+
+      expect(Reader.have_not_read(@email2)).to eq [@reader, @other_reader]
+    end
+
+    it "should not allow invalid parameter" do
+      [ 42, nil, 'foo', :foo, {} ].each do |not_a_readable|
+        expect {
+          Reader.have_not_read(not_a_readable)
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "should not allow unsaved readable" do
+      unsaved_readable = Email.new
+
+      expect {
+        Reader.have_not_read(unsaved_readable)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe :have_read do
+    it "should return an empty array" do
+      expect(Reader.have_read(@email1)).to be_empty
+      expect(Reader.have_read(@email2)).to be_empty
+    end
+
+    it "should return *only* the readers that have read the given object" do
+      @email1.mark_as_read! :for => @reader
+
+      expect(Reader.have_read(@email1)).to eq [@reader]
+      expect(Reader.have_read(@email1).count).to eq 1
+
+      expect(Reader.have_read(@email2)).to be_empty
+    end
+
+    it "should return the reader for all the object when all read" do
+      Email.mark_as_read! :all, :for => @reader
+
+      expect(Reader.have_read(@email1)).to eq [@reader]
+      expect(Reader.have_read(@email1).count).to eq 1
+
+      expect(Reader.have_read(@email2)).to eq [@reader]
+      expect(Reader.have_read(@email2).count).to eq 1
+    end
+
+    it "should not allow invalid parameter" do
+      [ 42, nil, 'foo', :foo, {} ].each do |not_a_readable|
+        expect {
+          Reader.have_read(not_a_readable)
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "should not allow unsaved readable" do
+      unsaved_readable = Email.new
+
+      expect {
+        Reader.have_read(unsaved_readable)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe :with_read_marks_for do
+    it "should return readers" do
+      expect(Reader.with_read_marks_for(@email1).to_a).to eq([@reader, @other_reader])
+    end
+
+    it "should have elements that respond to :read_mark_id" do
+      all_respond_to_read_mark_id = Reader.with_read_marks_for(@email1).to_a.all? do |reader|
+        reader.respond_to?(:read_mark_id)
+      end
+
+      expect(all_respond_to_read_mark_id).to be_truthy
+    end
+
+    it "should be countable" do
+      expect(Reader.with_read_marks_for(@email1).count(:number)).to eq(2)
+    end
+
+    it "should not allow invalid parameter" do
+      [ 42, nil, 'foo', :foo, {} ].each do |not_a_readable|
+        expect {
+          Reader.with_read_marks_for(not_a_readable)
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "should not allow unsaved readable" do
+      unsaved_readable = Email.new
+
+      expect {
+        Reader.with_read_marks_for(unsaved_readable)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe :have_read? do
+    it "should recognize read objects" do
+      expect(@reader.have_read?(@email1)).to be_falsey
+      expect(@reader.have_read?(@email2)).to be_falsey
+    end
+
+    it "should handle updating object" do
+      @email1.mark_as_read! :for => @reader
+      wait
+      expect(@reader.have_read?(@email1)).to be_truthy
+
+      @email1.update_attributes! :subject => 'changed'
+      expect(@reader.have_read?(@email1)).to be_falsey
+    end
+
+    it "should raise error for invalid argument" do
+      expect {
+        @reader.have_read?(42)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "should work with eager-loaded read marks" do
+      @email1.mark_as_read! :for => @reader
+
+      expect {
+        readers = Reader.with_read_marks_for(@email1).to_a
+
+        expect(readers[0].have_read?(@email1)).to be_truthy
+        expect(readers[1].have_read?(@email1)).to be_falsey
+      }.to perform_queries(1)
+    end
+  end
+end


### PR DESCRIPTION
Created similar scopes currently existing for `Readable` in `Reader`.
- `with_read_marks_for(readable)`: from the base scope of Readers(users) returns all with the read marks for the given readable.
- `have_read(readable)`: from the base scope of Readers(users) returns all which **have read** the `readable`
- `have_not_read`: from the base scope of Readers(users) returns all which **have not read** the `readable`
- `join_read_marks(readable)`: Joins the read_marks to the readers

Created as well the instance class in reader:
- `have_read?(readable)`: returns true/false if the Reader instance has read the readable.

For all this work, I also created a set of validations to the Reader.