### PR TITLE
Fixed longstanding bug with `with_read_marks_for`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ User.have_read(message1)
 User.have_read(message2)
 # => [ user1 ]
 
+## Get all users including their read status for a given message
+users = User.with_read_marks_for(message1)
+# => [ user1, user2 ]
+users[0].have_read?(message1)
+# => true
+users[1].have_read?(message2)
+# => false
+
 # Optional: Cleaning up unneeded markers.
 # Do this in a cron job once a day.
 Message.cleanup_read_marks!

--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -111,7 +111,7 @@ module Unread
 
     module InstanceMethods
       def unread?(user)
-        if self.respond_to?(:read_mark_id) and read_mark_id_belongs_to?(user)
+        if self.respond_to?(:read_mark_id) && read_mark_id_belongs_to?(user)
           # For use with scope "with_read_marks_for"
           return false if self.read_mark_id
 

--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -111,7 +111,7 @@ module Unread
 
     module InstanceMethods
       def unread?(user)
-        if self.respond_to?(:read_mark_id)
+        if self.respond_to?(:read_mark_id) and read_mark_id_belongs_to?(user)
           # For use with scope "with_read_marks_for"
           return false if self.read_mark_id
 
@@ -140,6 +140,12 @@ module Unread
 
       def read_mark(user)
         read_marks.where(:user_id => user.id).first
+      end
+
+      private
+
+      def read_mark_id_belongs_to?(user)
+        self.read_mark_user_id == user.id
       end
     end
   end

--- a/lib/unread/readable_scopes.rb
+++ b/lib/unread/readable_scopes.rb
@@ -35,7 +35,7 @@ module Unread
       end
 
       def with_read_marks_for(user)
-        join_read_marks(user).select("#{table_name}.*, read_marks.id AS read_mark_id")
+        join_read_marks(user).select("#{table_name}.*, read_marks.id AS read_mark_id, #{user.id} AS read_mark_user_id")
       end
     end
   end

--- a/lib/unread/reader.rb
+++ b/lib/unread/reader.rb
@@ -26,12 +26,19 @@ module Unread
       end
 
       def have_read?(readable)
-        if self.respond_to?(:read_mark_id)
+        if self.respond_to?(:read_mark_id) and read_mark_id_belongs_to?(readable)
           # For use with scope "with_read_marks_for"
           !self.read_mark_id.nil?
         else
           !self.class.have_not_read(readable).exists?(self.id)
         end
+      end
+
+      private
+
+      def read_mark_id_belongs_to?(readable)
+        self.read_mark_readable_type == readable.class.name and
+        (self.read_mark_readable_id.nil? or self.read_mark_readable_id == readable.id)
       end
     end
   end

--- a/lib/unread/reader.rb
+++ b/lib/unread/reader.rb
@@ -26,7 +26,7 @@ module Unread
       end
 
       def have_read?(readable)
-        if self.respond_to?(:read_mark_id) and read_mark_id_belongs_to?(readable)
+        if self.respond_to?(:read_mark_id) && read_mark_id_belongs_to?(readable)
           # For use with scope "with_read_marks_for"
           !self.read_mark_id.nil?
         else
@@ -37,8 +37,8 @@ module Unread
       private
 
       def read_mark_id_belongs_to?(readable)
-        self.read_mark_readable_type == readable.class.name and
-        (self.read_mark_readable_id.nil? or self.read_mark_readable_id == readable.id)
+        self.read_mark_readable_type == readable.class.base_class.name &&
+        (self.read_mark_readable_id.nil? || self.read_mark_readable_id == readable.id)
       end
     end
   end

--- a/lib/unread/reader_scopes.rb
+++ b/lib/unread/reader_scopes.rb
@@ -19,7 +19,9 @@ module Unread
       end
 
       def with_read_marks_for(readable)
-        join_read_marks(readable).select("#{table_name}.*, read_marks.id AS read_mark_id")
+        join_read_marks(readable).select("#{table_name}.*, read_marks.id AS read_mark_id,
+                                         '#{readable.class.base_class.name}' AS read_mark_readable_type,
+                                          #{readable.try(readable.class.primary_key)} AS read_mark_readable_id")
       end
     end
   end

--- a/spec/readable_spec.rb
+++ b/spec/readable_spec.rb
@@ -218,6 +218,14 @@ describe Unread::Readable do
       expect(emails[0].unread?(@reader)).to be_truthy
       expect(emails[1].unread?(@reader)).to be_truthy
     end
+
+    it "should work with eager-loaded read marks for the correct reader" do
+      @email1.mark_as_read! :for => @reader
+
+      emails = Email.with_read_marks_for(@reader).to_a
+      expect(emails[0].unread?(@reader)).to be_falsey
+      expect(emails[0].unread?(@other_reader)).to be_truthy
+    end
   end
 
   describe '#mark_as_read!' do

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -149,5 +149,13 @@ describe Unread::Reader do
         expect(readers[1].have_read?(@email1)).to be_falsey
       }.to perform_queries(1)
     end
+
+    it "should work with eager-loaded read marks for the correct readable" do
+      @email1.mark_as_read! :for => @reader
+
+      readers = Reader.with_read_marks_for(@email1).to_a
+      expect(readers[0].have_read?(@email1)).to be_truthy
+      expect(readers[0].have_read?(@email2)).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
There was a bug explained with the next code snippets:
Suppose:
```ruby
message1 = Message.create!
user1 = User.create!
user2 = User.create!
message1.mark_as_read! :for => user1
```

expect behavior: 
```ruby
messages = Message.with_read_marks_for(user1)
# => [ message1 ] with read_mark_id
messages[0].unread?(user1) #check message1, if is unread? by user1
# => false
messages[0].unread?(user2) #check message1, if is unread? by user2
# => true, expect user2 to have unread message1
```

current behavior: 
```ruby
messages = Message.with_read_marks_for(user1)
# => [ message1 ] with read_mark_id
messages[0].unread?(user1) #check message1, if is unread? by user1
# => false
messages[0].unread?(user2) #check message1, if is unread? by user2
# => false ===>BUG<===
```

This happens because `with_read_marks_for` just joins with the read_mark_id, but there is never any indication as to **who** owns the `read_mark_id`, so currently we just assume it belongs to all `readables`

The same bug was implemented in my previous branch for readers(User), but gets fixed here too.

### Fix:
I added `read_mark_user_id` for `readables` scope and `read_mark_readable_type` and `read_mark_readable_id` for `reader` scopes.

Now inside `unread?` and `have_read?`, besides testing if the record `respond_to?(:read_mark_id)` we also test if the `read_mark_id` belongs to the user/readable being tested, otherwise it would load the whole set of `unread_by(user)`/`have_not_read(readable)` and verify if the object that we are looking for is present.