### PR TITLE
PostgreSQL issue with `readers_to_cleanup`

### DIFF
--- a/lib/unread/garbage_collector.rb
+++ b/lib/unread/garbage_collector.rb
@@ -30,7 +30,7 @@ module Unread
         reader_scope.
         joins(:read_marks).
         where(:read_marks => { :readable_type => readable_class.base_class.name }).
-        group('read_marks.reader_type, read_marks.reader_id').
+        group('read_marks.reader_type, read_marks.reader_id, ' + reader_class.base_class.name.pluralize + '.id').
         having('COUNT(read_marks.id) > 1')
     end
 

--- a/lib/unread/garbage_collector.rb
+++ b/lib/unread/garbage_collector.rb
@@ -30,7 +30,7 @@ module Unread
         reader_scope.
         joins(:read_marks).
         where(:read_marks => { :readable_type => readable_class.base_class.name }).
-        group('read_marks.reader_type, read_marks.reader_id, ' + reader_class.base_class.name.pluralize + '.id').
+        group("read_marks.reader_type, read_marks.reader_id, #{reader_class.quoted_table_name}.#{reader_class.quoted_primary_key}").
         having('COUNT(read_marks.id) > 1')
     end
 


### PR DESCRIPTION
Postgres complains that `users.id` needs to be used in the `group()` in order for the query to succeed.