### PR TITLE
Flexible behaviour for STI models as Readable

### DIFF
--- a/lib/unread/readable_scopes.rb
+++ b/lib/unread/readable_scopes.rb
@@ -5,7 +5,7 @@ module Unread
         assert_reader(reader)
 
         joins "LEFT JOIN read_marks
-                ON read_marks.readable_type  = '#{base_class.name}'
+                ON read_marks.readable_type  = '#{readable_parent.name}'
                AND read_marks.readable_id    = #{quoted_table_name}.#{quoted_primary_key}
                AND read_marks.reader_id      = #{quote_bound_value(reader.id)}
                AND read_marks.reader_type    = #{quote_bound_value(reader.class.base_class.name)}

--- a/lib/unread/reader.rb
+++ b/lib/unread/reader.rb
@@ -15,7 +15,8 @@ module Unread
     module InstanceMethods
       def read_mark_global(klass)
         @read_mark_global ||= {}
-        @read_mark_global[klass] ||= read_marks.where(:readable_type => klass.base_class.name).global.first
+        readable_klass = klass.readable_parent
+        @read_mark_global[readable_klass] ||= read_marks.where(:readable_type => readable_klass.name).global.first
       end
 
       def forget_memoized_read_mark_global
@@ -32,9 +33,9 @@ module Unread
       end
 
       private
-
+      
       def read_mark_id_belongs_to?(readable)
-        self.read_mark_readable_type == readable.class.base_class.name &&
+        self.read_mark_readable_type == readable.class.name &&
         (self.read_mark_readable_id.nil? || self.read_mark_readable_id.to_i == readable.id)
       end
 

--- a/lib/unread/reader_scopes.rb
+++ b/lib/unread/reader_scopes.rb
@@ -11,7 +11,7 @@ module Unread
         assert_readable(readable)
 
         joins "LEFT JOIN read_marks
-                ON read_marks.readable_type  = '#{readable.class.base_class.name}'
+                ON read_marks.readable_type  = '#{readable.class.readable_parent.name}'
                AND (read_marks.readable_id   = #{readable.id} OR read_marks.readable_id IS NULL)
                AND read_marks.reader_id      = #{quoted_table_name}.#{quoted_primary_key}
                AND read_marks.reader_type    = '#{connection.quote_string base_class.name}'
@@ -28,7 +28,7 @@ module Unread
 
       def with_read_marks_for(readable)
         join_read_marks(readable).select("#{quoted_table_name}.*, read_marks.id AS read_mark_id,
-                                         '#{readable.class.base_class.name}' AS read_mark_readable_type,
+                                         '#{readable.class.name}' AS read_mark_readable_type,
                                           #{readable.id} AS read_mark_readable_id")
       end
     end


### PR DESCRIPTION
Allows STI subclasses to be defined as readable without affecting parent classes.

For example: 

```
class Message < ActiveRecord::Base
    ...
end
```
```
class SystemMessage < Message
    acts_as_readable :on => :updated_at
end
```

```
class UserMessage < Message
    acts_as_readable :on => :updated_at
end
```

The modification allows to mark UserMessages all as read without doing the same (unintentional) for all Messages (including the SystemMessages)