### PR TITLE
Fix a postgresql warning about OID 705 when running rspec tests

### DIFF
--- a/lib/unread/readable_scopes.rb
+++ b/lib/unread/readable_scopes.rb
@@ -35,9 +35,10 @@ module Unread
       end
 
       def with_read_marks_for(reader)
+        read_mark_reader_type_cast = connection.adapter_name.downcase.to_sym == :postgresql ? "::character(255)" : ""
         join_read_marks(reader).select("#{quoted_table_name}.*,
                                         #{ReadMark.quoted_table_name}.id AS read_mark_id,
-                                        #{quote_bound_value(reader.class.base_class.name)} AS read_mark_reader_type,
+                                        #{quote_bound_value(reader.class.base_class.name)}#{read_mark_reader_type_cast} AS read_mark_reader_type,
                                         #{quote_bound_value(reader.id)} AS read_mark_reader_id")
       end
     end


### PR DESCRIPTION
Hello !

This warning is displayed when running test with rspec and postgresql :
```unknown OID 705: failed to recognize type of 'read_mark_reader_type'. It will be treated as String.```

You can see this warning in the project travis logs : [https://travis-ci.org/ledermann/unread/jobs/118972216](https://travis-ci.org/ledermann/unread/jobs/118972216)

Reading [this rails PR](https://github.com/rails/rails/pull/10498/files) the
fix for postgresql is to cast values when using 'AS' in custom queries.

Introduce that specific check for postgres seems ugly, but the problem appears only for postgres.
I'm not sure what would be the proper way to fix it, so I can make some changes if needed ;). 
