### PR TITLE
Add unique constraint to reader and readable

### DIFF
--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -6,7 +6,7 @@ class UnreadMigration < ActiveRecord::Migration
       t.datetime :timestamp
     end
 
-    add_index ReadMark, [:reader_id, :reader_type, :readable_type, :readable_id], name: 'read_marks_reader_readable_index'
+    add_index ReadMark, [:reader_id, :reader_type, :readable_type, :readable_id], name: 'read_marks_reader_readable_index', unique: true
   end
 
   def self.down

--- a/spec/unread/readable_spec.rb
+++ b/spec/unread/readable_spec.rb
@@ -266,6 +266,20 @@ describe Unread::Readable do
       expect(@email2.unread?(@reader)).to be_falsey
     end
 
+    it "should mark the rest as read when the first record is not unique" do
+      Email.mark_as_read! [ @email1 ], for: @reader
+
+      allow(@email1).to receive_message_chain("read_marks.build").and_return(@email1.read_marks.build)
+      allow(@email1).to receive_message_chain("read_marks.where").and_return([])
+
+      expect do
+        Email.mark_as_read! [ @email1, @email2 ], for: @reader
+      end.to change(ReadMark, :count).by(1)
+
+      expect(@email1.unread?(@reader)).to be_falsey
+      expect(@email2.unread?(@reader)).to be_falsey
+    end
+
     it "should perform less queries if the objects are already read" do
       Email.mark_as_read! :all, :for => @reader
 


### PR DESCRIPTION
The readable and reader is not unique before, and `mark_array_as_read` is not thread safe.

Our production app has lots of duplicates generated under high load. And this further result in duplicated records returned in `.with_readmarks_for(user)`.

This PR adds a unique constraint to the table and handle the error.


Still working on a test for this.