### PR TITLE
use latin1 in case of mysql

### DIFF
--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -1,6 +1,6 @@
 class UnreadMigration < Unread::MIGRATION_BASE_CLASS
   def self.up
-    create_table ReadMark, force: true do |t|
+    create_table ReadMark, force: true, options: create_options do |t|
       t.references :readable, polymorphic: { null: false }
       t.references :reader,   polymorphic: { null: false }
       t.datetime :timestamp
@@ -11,5 +11,14 @@ class UnreadMigration < Unread::MIGRATION_BASE_CLASS
 
   def self.down
     drop_table ReadMark
+  end
+
+  def create_options
+    options = ''
+    if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) \
+      && ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+      options = 'DEFAULT CHARSET=latin1'
+    end
+    options
   end
 end

--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -13,7 +13,7 @@ class UnreadMigration < Unread::MIGRATION_BASE_CLASS
     drop_table ReadMark
   end
 
-  def create_options
+  def self.create_options
     options = ''
     if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) \
       && ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)


### PR DESCRIPTION
this PR is for #83 
I fixed migration error under the condition of  using mysql and utf8.

```
Mysql2::Error: Specified key was too long; max key length is 767 bytes:
CREATE UNIQUE INDEX `read_marks_reader_readable_index`  ON `read_marks` (`reader_id`, `reader_type`, `readable_type`, `readable_id`) 
```