### PR TITLE
allow any collection to be marked as read

### DIFF
--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -9,18 +9,18 @@ module Unread
 
         if target == :all
           reset_read_marks_for_user(reader)
-        elsif target.is_a?(Array)
+        elsif target.respond_to?(:each)
           mark_array_as_read(target, reader)
         else
           raise ArgumentError
         end
       end
 
-      def mark_array_as_read(array, reader)
+      def mark_array_as_read(collection, reader)
         ReadMark.transaction do
           global_timestamp = reader.read_mark_global(self).try(:timestamp)
 
-          array.each do |obj|
+          collection.each do |obj|
             raise ArgumentError unless obj.is_a?(self)
             timestamp = obj.send(readable_options[:on])
 

--- a/spec/unread/readable_spec.rb
+++ b/spec/unread/readable_spec.rb
@@ -288,6 +288,14 @@ describe Unread::Readable do
       }.to perform_queries(1)
     end
 
+    it "should allow a collection of records to be marked as read" do
+      Email.mark_as_read! Email.all, for: @reader
+
+      expect(@email1.unread?(@reader)).to be_falsey
+      expect(@email2.unread?(@reader)).to be_falsey
+    end
+
+
     it "should mark all objects as read" do
       Email.mark_as_read! :all, for: @reader
 


### PR DESCRIPTION
My goal is to mark a collection of books as read. I don't want to mark all as read, just a select subset.

I'm attempting to use unread like so:

```ruby
books = current_user.expensive_books # just some custom query that is a subset of books
Book.mark_as_read!(books, for: current_user)
```

It breaks with the current code as books isn't type Array. I can turn the query into an array I suppose, but I'd rather just pass the collection itself in as is. Does that seem reasonable?