### PR TITLE
Reduce number of transactions for #mark_collection_as_read

### DIFF
--- a/lib/unread/read_mark.rb
+++ b/lib/unread/read_mark.rb
@@ -1,5 +1,5 @@
 class ReadMark < ActiveRecord::Base
-  belongs_to :readable, polymorphic: true
+  belongs_to :readable, polymorphic: true, inverse_of: :read_marks
 
   validates_presence_of :reader_id, :reader_type, :readable_type
 

--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -27,16 +27,16 @@ module Unread
             if global_timestamp && global_timestamp >= timestamp
               # The object is implicitly marked as read, so there is nothing to do
             else
-              mark_collection_item_as_read(obj, reader)
+              mark_collection_item_as_read(obj, reader, timestamp)
             end
           end
         end
       end
 
-      def mark_collection_item_as_read(obj, reader)
+      def mark_collection_item_as_read(obj, reader, timestamp)
         marking_proc = proc {
           rm = obj.read_marks.find_or_initialize_by(reader: reader)
-          rm.timestamp = obj.send(readable_options[:on])
+          rm.timestamp = timestamp
           rm.save!
         }
 

--- a/lib/unread/readable.rb
+++ b/lib/unread/readable.rb
@@ -34,7 +34,7 @@ module Unread
       end
 
       def mark_collection_item_as_read(obj, reader)
-        marking_proc = proc { |obj|
+        marking_proc = proc {
           rm = obj.read_marks.find_or_initialize_by(reader: reader)
           rm.timestamp = obj.send(readable_options[:on])
           rm.save!
@@ -43,14 +43,14 @@ module Unread
         if using_postgresql?
           ReadMark.transaction(requires_new: true) do
             begin
-              marking_proc.call(obj)
+              marking_proc.call
             rescue ActiveRecord::RecordNotUnique
               raise ActiveRecord::Rollback
             end
           end
         else
           begin
-            marking_proc.call(obj)
+            marking_proc.call
           rescue ActiveRecord::RecordNotUnique
             # The object is explicitly marked as read, so there is nothing to do
           end

--- a/spec/unread/readable_spec.rb
+++ b/spec/unread/readable_spec.rb
@@ -269,8 +269,8 @@ describe Unread::Readable do
     it "should mark the rest as read when the first record is not unique" do
       Email.mark_as_read! [ @email1 ], for: @reader
 
-      allow(@email1).to receive_message_chain("read_marks.build").and_return(@email1.read_marks.build)
-      allow(@email1).to receive_message_chain("read_marks.where").and_return([])
+      allow(@email1).to receive_message_chain("read_marks.find_or_initialize_by")
+        .and_return(@email1.read_marks.build(reader: @reader))
 
       expect do
         Email.mark_as_read! [ @email1, @email2 ], for: @reader
@@ -294,7 +294,6 @@ describe Unread::Readable do
       expect(@email1.unread?(@reader)).to be_falsey
       expect(@email2.unread?(@reader)).to be_falsey
     end
-
 
     it "should mark all objects as read" do
       Email.mark_as_read! :all, for: @reader
@@ -329,6 +328,11 @@ describe Unread::Readable do
       expect {
         Email.mark_as_read! :foo, :bar
       }.to raise_error(ArgumentError)
+    end
+
+    it "should work with STI readers" do
+      Email.mark_as_read! [ @email1 ], for: Customer.find(@sti_reader.id)
+      expect(@email1.unread?(@sti_reader)).to be_falsey
     end
   end
 


### PR DESCRIPTION
Inner transactions are not necessary (if I'm not missing something obvious) and can be replaced as was done in this PR.

Fixes https://github.com/ledermann/unread/issues/80.