### PR TITLE
Quote the readable.id in Unread::Reader::Scopes

### DIFF
--- a/lib/unread/reader_scopes.rb
+++ b/lib/unread/reader_scopes.rb
@@ -31,7 +31,7 @@ module Unread
 
         join_read_marks(readable).select("#{quoted_table_name}.*,
                                           #{ReadMark.quoted_table_name}.id AS read_mark_id,
-                                          #{quote_bound_value readable.class.name}#{postgresql_string_cast} AS read_mark_readable_type,
+                                          #{quote_bound_value(readable.class.name)}#{postgresql_string_cast} AS read_mark_readable_type,
                                           #{quote_bound_value(readable.id)} AS read_mark_readable_id")
       end
     end

--- a/lib/unread/reader_scopes.rb
+++ b/lib/unread/reader_scopes.rb
@@ -12,7 +12,7 @@ module Unread
 
         joins "LEFT JOIN #{ReadMark.quoted_table_name}
                 ON #{ReadMark.quoted_table_name}.readable_type  = '#{readable.class.readable_parent.name}'
-               AND (#{ReadMark.quoted_table_name}.readable_id   = #{readable.id} OR #{ReadMark.quoted_table_name}.readable_id IS NULL)
+               AND (#{ReadMark.quoted_table_name}.readable_id   = #{quote_bound_value(readable.id)} OR #{ReadMark.quoted_table_name}.readable_id IS NULL)
                AND #{ReadMark.quoted_table_name}.reader_id      = #{quoted_table_name}.#{quoted_primary_key}
                AND #{ReadMark.quoted_table_name}.reader_type    = '#{connection.quote_string base_class.name}'
                AND #{ReadMark.quoted_table_name}.timestamp     >= '#{connection.quoted_date readable.send(readable.class.readable_options[:on])}'"
@@ -32,7 +32,7 @@ module Unread
         join_read_marks(readable).select("#{quoted_table_name}.*,
                                           #{ReadMark.quoted_table_name}.id AS read_mark_id,
                                           #{quote_bound_value readable.class.name}#{postgresql_string_cast} AS read_mark_readable_type,
-                                          #{readable.id} AS read_mark_readable_id")
+                                          #{quote_bound_value(readable.id)} AS read_mark_readable_id")
       end
     end
   end


### PR DESCRIPTION
This PR fixes the generated SQL when the `readable.id` is a `UUID`.

For example when running:

```Ruby
> user.have_read?(book)
```

the generated SQL is:

```SQL
  Punter Exists (0.7ms)  SELECT  1 AS one FROM "people" LEFT JOIN "read_marks"
                ON "read_marks".readable_type  = 'Book'
               AND ("read_marks".readable_id   = a4691c66-344f-4ab1-8dd4-16614f6cbb52 OR "read_marks".readable_id IS NULL)
               AND "read_marks".reader_id      = "user"."id"
               AND "read_marks".reader_type    = 'User'
               AND "read_marks".timestamp     >= '2019-08-03 10:43:02.138041' WHERE "people"."type" IN ('User') AND ("read_marks".id IS NULL) AND "people"."id" = $1 LIMIT $2  [["id", "cf7144b0-2814-48d3-ba17-b46a00b46246"], ["LIMIT", 1]]
```

and it fails with the following error:

```SQL
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near "f"
LINE 3: ...    AND ("read_marks".readable_id   = a4691c66-344f-4ab1-8dd...
                                                             ^
```

Quoting the `readable.id` fixes the problem. Related to #60.