### PR TITLE
Added optional: true to reader's belongs_to [Fixes #120]

### DIFF
--- a/lib/unread/base.rb
+++ b/lib/unread/base.rb
@@ -8,7 +8,11 @@ module Unread
       ReadMark.reader_classes ||= []
 
       unless ReadMark.reader_classes.include?(self)
-        ReadMark.belongs_to :reader, polymorphic: true, inverse_of: :read_marks
+        if ActiveRecord::VERSION::MAJOR < 5
+          ReadMark.belongs_to :reader, polymorphic: true, inverse_of: :read_marks
+        else
+          ReadMark.belongs_to :reader, polymorphic: true, inverse_of: :read_marks, optional: true
+        end
 
         has_many :read_marks, dependent: :delete_all, as: :reader, inverse_of: :reader
 

--- a/lib/unread/read_mark.rb
+++ b/lib/unread/read_mark.rb
@@ -1,5 +1,5 @@
 class ReadMark < ActiveRecord::Base
-  belongs_to :readable, polymorphic: true, inverse_of: :read_marks, optional: true
+  belongs_to :readable, polymorphic: true, inverse_of: :read_marks
 
   validates_presence_of :reader_id, :reader_type, :readable_type
 

--- a/lib/unread/read_mark.rb
+++ b/lib/unread/read_mark.rb
@@ -1,5 +1,5 @@
 class ReadMark < ActiveRecord::Base
-  belongs_to :readable, polymorphic: true, inverse_of: :read_marks
+  belongs_to :readable, polymorphic: true, inverse_of: :read_marks, optional: true
 
   validates_presence_of :reader_id, :reader_type, :readable_type
 

--- a/spec/unread/readable_spec.rb
+++ b/spec/unread/readable_spec.rb
@@ -253,6 +253,34 @@ describe Unread::Readable do
 
       expect(@reader.read_marks.single.count).to eq 1
     end
+
+    context 'when the reader class defines a default_scope that excludes tha reader instance' do
+      before { ReadMark.stub(belongs_to_required_by_default: true) }
+
+      let!(:reader_class) do
+        CustomReader = Class.new(ActiveRecord::Base) do
+          self.primary_key = 'number'
+          self.table_name = 'readers'
+
+          acts_as_reader
+
+          default_scope { where.not(name: 'foo') }
+        end
+      end
+      let!(:reader) { reader_class.create!(name: 'foo') }
+      let(:document) { Document.create! }
+
+      before do
+        wait
+        document
+      end
+
+      subject { document.mark_as_read!(for: reader) }
+
+      it 'does not raise_error' do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 
   describe '.mark_as_read!' do


### PR DESCRIPTION
Fixes the issue in Rails 6+ that has by default `belongs_to_required_by_default = true` setting enabled.

As a a result if any reader defines default scope and reader instance does not match that scope `mark_as_read!` fails with `Reader must exist` then

Thanks.