### PR TITLE
add 'null: false' option for timestamp fields in migration generator

### DIFF
--- a/lib/generators/unread/migration/templates/migration.rb
+++ b/lib/generators/unread/migration/templates/migration.rb
@@ -3,7 +3,7 @@ class UnreadMigration < Unread::MIGRATION_BASE_CLASS
     create_table ReadMark, force: true, options: create_options do |t|
       t.references :readable, polymorphic: { null: false }
       t.references :reader,   polymorphic: { null: false }
-      t.datetime :timestamp
+      t.datetime :timestamp, null: false
     end
 
     add_index ReadMark, [:reader_id, :reader_type, :readable_type, :readable_id], name: 'read_marks_reader_readable_index', unique: true


### PR DESCRIPTION
closes #113 