### PR TITLE
Do not prematurely load `ActiveRecord::Base`

### DIFF
--- a/lib/unread.rb
+++ b/lib/unread.rb
@@ -1,7 +1,6 @@
 require 'active_record'
 
 require 'unread/base'
-require 'unread/read_mark'
 require 'unread/readable'
 require 'unread/reader'
 require 'unread/readable_scopes'
@@ -9,10 +8,14 @@ require 'unread/reader_scopes'
 require 'unread/garbage_collector'
 require 'unread/version'
 
-ActiveRecord::Base.send :include, Unread
-
 Unread::MIGRATION_BASE_CLASS = if ActiveRecord::VERSION::MAJOR >= 5
   ActiveRecord::Migration[5.0]
 else
   ActiveRecord::Migration
+end
+
+ActiveSupport.on_load(:active_record) do
+  require 'unread/read_mark'
+
+  include Unread
 end


### PR DESCRIPTION
`unread` prematurely loads `ActiveRecord::Base`, which causes some bad behavior - see https://github.com/rails/rails/issues/46567 for the details.