### PR TITLE
Fix migration generator to support Rails 7.1

### DIFF
--- a/lib/generators/unread/migration/migration_generator.rb
+++ b/lib/generators/unread/migration/migration_generator.rb
@@ -13,11 +13,22 @@ module Unread
     end
 
     def self.next_migration_number(dirname)
-      if ActiveRecord::Base.timestamped_migrations
+      if self.timestamped_migrations?
         Time.now.utc.strftime("%Y%m%d%H%M%S")
       else
         "%.3d" % (current_migration_number(dirname) + 1)
       end
+    end
+
+    def self.timestamped_migrations?
+      (
+        ActiveRecord::Base.respond_to?(:timestamped_migrations) &&
+          ActiveRecord::Base.timestamped_migrations
+      ) ||
+        (
+          ActiveRecord.respond_to?(:timestamped_migrations) &&
+            ActiveRecord.timestamped_migrations
+        )
     end
   end
 end


### PR DESCRIPTION
As in 50285aca0b6ed44be192c7c808fb05ce85236b33 we need to support the new location of `timestamped_migrations`